### PR TITLE
Remove preceeding whitespaces to maintain indentation

### DIFF
--- a/charts/c11h-basic/templates/service.yaml
+++ b/charts/c11h-basic/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: {{ template "chart.label" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{ if .Values.service.metrics.enabled -}}
+{{- if .Values.service.metrics.enabled }}
     metrics: "true"
-{{ end }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Before it looked like this:
```
metadata:
  name: ka-api-c11h-basic
  labels:
    app: c11h-basic
    chart: c11h-basic-0.3.0
    release: ka-api
    heritage: Tiller
metrics: "true"
```