### PR TITLE
pass resource limits as envvars. 

### DIFF
--- a/charts/c11h-basic/templates/deployment.yaml
+++ b/charts/c11h-basic/templates/deployment.yaml
@@ -70,6 +70,26 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
           {{- end }}
           env:
+            - name: CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: {{ .Values.name }}
+                  resource: requests.cpu
+            - name: CPU_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: {{ .Values.name }}
+                  resource: limits.cpu
+            - name: MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: {{ .Values.name }}
+                  resource: requests.memory
+            - name: MEM_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: {{ .Values.name }}
+                  resource: limits.memory
             {{- range .Values.image.env }}
             - name: {{ .name}}
             {{ if .value }}


### PR DESCRIPTION
useful for java-applications to setup xmx opts dynamically during startup
as processes/user see the nodes total memory only for memory allocation