### PR TITLE
set default maxUnavaliableCount to 0

### DIFF
--- a/charts/c11h-basic/values.yaml
+++ b/charts/c11h-basic/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 # See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 rollingUpdate:
   maxSurgeCount: 1
-  maxUnavaliableCount: 1
+  maxUnavaliableCount: 0
 
 
 ## Custom extra labels


### PR DESCRIPTION
This helps avoid the following problem:
if maxUnavaliableCount=1 and number of replicas is 1,
then the deployments considers itself as available even if no
replicas are running:
minimum replicas to be available = desired replicas - maxUnavaliableCount = 1 - 1 = 0