### PR TITLE
add support of pod annotations

### DIFF
--- a/charts/c11h-basic/Chart.yaml
+++ b/charts/c11h-basic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for basic Kubernetes applications
 name: c11h-basic
-version: 0.5.5
+version: 0.5.6

--- a/charts/c11h-basic/templates/deployment.yaml
+++ b/charts/c11h-basic/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 8}}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 10 }}
+      {{- end }}
     spec:
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/c11h-basic/values.yaml
+++ b/charts/c11h-basic/values.yaml
@@ -14,6 +14,10 @@ rollingUpdate:
 # labels:
 #   foo: "bar"
 
+# Custom pod annotations
+# podAnnotations:
+#   foo: "bar"
+
 image:
   repository: nginx
   tag: stable


### PR DESCRIPTION
Currently pod annotations are not supported in the deployment template. In order not to mix it with annotations for deployment itself or other entities I named the block `pod-annotations`.